### PR TITLE
Ignore undersocored vars in assign

### DIFF
--- a/lib/platformos_check/checks/unused_assign.rb
+++ b/lib/platformos_check/checks/unused_assign.rb
@@ -34,6 +34,8 @@ module PlatformosCheck
     end
 
     def on_assign(node)
+      return if ignore_underscored?(node)
+
       @templates[node.app_file.name].assign_nodes[node.value.to] = node
     end
 
@@ -42,13 +44,13 @@ module PlatformosCheck
     end
 
     def on_function(node)
-      return if node.value.to.start_with?('_')
+      return if ignore_underscored?(node)
 
       @templates[node.app_file.name].assign_nodes[node.value.to] = node
     end
 
     def on_graphql(node)
-      return if node.value.to.start_with?('_')
+      return if ignore_underscored?(node)
 
       @templates[node.app_file.name].assign_nodes[node.value.to] = node
     end
@@ -100,6 +102,12 @@ module PlatformosCheck
           end
         end
       end
+    end
+
+    private
+
+    def ignore_underscored?(node)
+      node.value.to.start_with?('_')
     end
   end
 end

--- a/test/checks/unused_assign_test.rb
+++ b/test/checks/unused_assign_test.rb
@@ -16,6 +16,17 @@ class UnusedAssignTest < Minitest::Test
     END
   end
 
+  def test_do_not_reports_unused_assigns_if_starts_with_underscore
+    offenses = analyze_platformos_app(
+      PlatformosCheck::UnusedAssign.new,
+      "app/views/partials/index.liquid" => <<~END
+        {% assign _x = 'foo' %}
+      END
+    )
+
+    assert_offenses("", offenses)
+  end
+
   def test_reports_unused_function_assigns
     offenses = analyze_platformos_app(
       PlatformosCheck::UnusedAssign.new,


### PR DESCRIPTION
I have such piece of code
```liquid
assign _ = event_slim | hash_delete_key: 'type'
```